### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,5 +69,5 @@ $ mkdocs build
 
 [build-status-image]: https://secure.travis-ci.org/jatir/django-rest-framework-last-modified.png?branch=master
 [travis]: http://travis-ci.org/jatir/django-rest-framework-last-modified?branch=master
-[pypi-version]: https://pypip.in/version/djangorestframework-last-modified/badge.svg
+[pypi-version]: https://img.shields.io/pypi/v/djangorestframework-last-modified.svg
 [pypi]: https://pypi.python.org/pypi/djangorestframework-last-modified


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20djangorestframework-last-modified))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `djangorestframework-last-modified`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.